### PR TITLE
Use camelCase to more closely adhere to PSR-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ Or, create a composer.json file with the following contents and run "composer in
 ## API
 
 * [\Missing\Arrays::flatten](#arr_flatten)
-* [\Missing\Arrays::sort_by](#arr_sort_by)
+* [\Missing\Arrays::sortBy](#arr_sort_by)
 * [\Missing\Dates::parse](#date_parse)
 * [\Missing\Dates::strftime](#date_strftime)
 * [\Missing\Ints::ordinalize](#int_ordinalize)
 * [\Missing\Reflection::call](#reflection_call)
-* [\Missing\Strings::starts_with](#string_starts_with)
-* [\Missing\Strings::ends_with](#string_ends_with)
-* [\Missing\Strings::get_output](#string_get_output)
+* [\Missing\Strings::startsWith](#string_starts_with)
+* [\Missing\Strings::endsWith](#string_ends_with)
+* [\Missing\Strings::getOutput](#string_get_output)
 
 ### Arrays
 
@@ -40,11 +40,11 @@ Flattens an array containing arrays.
     \Missing\Arrays::flatten([1, [2, 3, [4, 5]]]) === [1, 2, 3, 4, 5]
 
 <a name="arr_sort_by"></a>
-#### $array = \Missing\Arrays::sort_by($array, $callback)
+#### $array = \Missing\Arrays::sortBy($array, $callback)
 
 Sorts $array by $callback($array_element).
 
-    \Missing\Arrays::sort_by(['abc', 'ab', 'a'], function ($a) {return strlen($a);}) === ['a', 'ab', 'abc']
+    \Missing\Arrays::sortBy(['abc', 'ab', 'a'], function ($a) {return strlen($a);}) === ['a', 'ab', 'abc']
 
 ### Dates
 
@@ -94,17 +94,17 @@ Calls private or protected method $methodName of $object with $arguments (an arr
 ### Strings
 
 <a name="string_starts_with"></a>
-#### $bool = \Missing\Strings::starts_with($haystack, $needle)
+#### $bool = \Missing\Strings::startsWith($haystack, $needle)
 
 Returns true if string $haystack starts with $needle (uses substr() - regexes not supported).
 
 <a name="string_ends_with"></a>
-#### $bool = \Missing\Strings::ends_with($haystack, $needle)
+#### $bool = \Missing\Strings::endsWith($haystack, $needle)
 
 Returns true if string $haystack ends with $needle (uses substr() - regexes not supported).
 
 <a name="string_get_output"></a>
-#### $string = \Missing\Strings::get_output($callback)
+#### $string = \Missing\Strings::getOutput($callback)
 
 Executes $callback, returns what it prints as a string.
 

--- a/src/Missing/Arrays.php
+++ b/src/Missing/Arrays.php
@@ -9,7 +9,7 @@ class Arrays {
     return $return;
   }
 
-  static function sort_by($array, $callback) {
+  static function sortBy($array, $callback) {
     if (!is_callable($callback) || !is_array($array)) {
       trigger_error('Arguments are in the wrong order', E_USER_ERROR);
     } //@codeCoverageIgnore

--- a/src/Missing/Dates.php
+++ b/src/Missing/Dates.php
@@ -3,7 +3,7 @@
 namespace Missing;
 
 class Dates {
-  static function parse_strptime($a) {
+  static function parseStrptime($a) {
     // Reset the timezone after using mktime
     $tz = date_default_timezone_get();
     date_default_timezone_set('UTC');
@@ -24,7 +24,7 @@ class Dates {
     foreach ($formats as $format) {
       $time = strptime($str, $format);
       if ($time !== false) {
-        return [self::parse_strptime($time), null];
+        return [self::parseStrptime($time), null];
       }
     }
 

--- a/src/Missing/Strings.php
+++ b/src/Missing/Strings.php
@@ -3,15 +3,15 @@
 namespace Missing;
 
 class Strings {
-  static function starts_with($haystack, $needle) {
+  static function startsWith($haystack, $needle) {
     return substr($haystack, 0, strlen($needle)) === $needle;
   }
 
-  static function ends_with($haystack, $needle) {
+  static function endsWith($haystack, $needle) {
     return substr($haystack, -strlen($needle)) === $needle;
   }
 
-  static function get_output($callback) {
+  static function getOutput($callback) {
     ob_start();
     call_user_func($callback);
     $s = ob_get_contents();

--- a/test/arrays_test.php
+++ b/test/arrays_test.php
@@ -15,7 +15,7 @@ class ArraysTest extends PHPUnit_Framework_TestCase {
   function testSortByInt() {
     $this->assertEquals(
       array('a', 'a', 'ab', 'abc', 'abcd'),
-      Missing\Arrays::sort_by(
+      Missing\Arrays::sortBy(
         array('abcd', 'ab', 'a', 'abc', 'a'),
         function ($a) { return strlen($a); }
       )
@@ -25,7 +25,7 @@ class ArraysTest extends PHPUnit_Framework_TestCase {
   function testSortByString() {
     $this->assertEquals(
       array('a333', 'b22', 'c1', 'd55555'),
-      Missing\Arrays::sort_by(
+      Missing\Arrays::sortBy(
         array('d55555', 'b22', 'a333', 'c1'),
         function ($a) { return $a; }
       )
@@ -35,7 +35,7 @@ class ArraysTest extends PHPUnit_Framework_TestCase {
   function testSortByArray() {
     $this->assertEquals(
       array(array(2, 'b'), array(2, 'c'), array(19, 'a')),
-      Missing\Arrays::sort_by(
+      Missing\Arrays::sortBy(
         array(array(19, 'a'), array(2, 'c'), array(2, 'b')),
         function ($a) { return $a; }
       )
@@ -44,6 +44,6 @@ class ArraysTest extends PHPUnit_Framework_TestCase {
 
   function testSortByTriggersError() {
     $this->setExpectedException('PHPUnit_Framework_Error');
-    Missing\Arrays::sort_by(function(){}, array());
+    Missing\Arrays::sortBy(function(){}, array());
   }
 }

--- a/test/dates_test.php
+++ b/test/dates_test.php
@@ -2,7 +2,7 @@
 
 class DatesTest extends PHPUnit_Framework_TestCase {
   function testParseStrptime() {
-    $this->assertEquals(1339009200, Missing\Dates::parse_strptime(array(
+    $this->assertEquals(1339009200, Missing\Dates::parseStrptime(array(
       'tm_sec' => 0,
       'tm_min' => 0,
       'tm_hour' => 19,

--- a/test/strings_test.php
+++ b/test/strings_test.php
@@ -2,19 +2,19 @@
 
 class StringsTest extends PHPUnit_Framework_TestCase {
   function testStartsWith() {
-    $this->assertTrue(Missing\Strings::starts_with('abc', 'a'));
-    $this->assertFalse(Missing\Strings::starts_with('abc', 'b'));
-    $this->assertFalse(Missing\Strings::starts_with('a', 'abc'));
+    $this->assertTrue(Missing\Strings::startsWith('abc', 'a'));
+    $this->assertFalse(Missing\Strings::startsWith('abc', 'b'));
+    $this->assertFalse(Missing\Strings::startsWith('a', 'abc'));
   }
 
   function testEndsWith() {
-    $this->assertTrue(Missing\Strings::ends_with('abc', 'c'));
-    $this->assertFalse(Missing\Strings::ends_with('abc', 'b'));
-    $this->assertFalse(Missing\Strings::ends_with('c', 'abc'));
+    $this->assertTrue(Missing\Strings::endsWith('abc', 'c'));
+    $this->assertFalse(Missing\Strings::endsWith('abc', 'b'));
+    $this->assertFalse(Missing\Strings::endsWith('c', 'abc'));
   }
 
   function testGetOutput() {
-    $this->assertEquals('a simple test', Missing\Strings::get_output(function () {
+    $this->assertEquals('a simple test', Missing\Strings::getOutput(function () {
       echo 'a simple test';
     }));
   }


### PR DESCRIPTION
I've been wanting to make this change for a while. Now that we're breaking the API for PHP7 support, we may as well do this at the same time.
