### PR TITLE
update(readme): Incorrect `dev-master` changed to `dev-main` - closes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ Install [composer](http://getcomposer.org/).
 
 Run the following in the root of your project:
 
-    composer require dxw/php-missing dev-master
+    composer require dxw/php-missing dev-main
 
 Or, create a composer.json file with the following contents and run "composer install":
 
     {
       "require": {
-        "dxw/php-missing": "dev-master"
+        "dxw/php-missing": "dev-main"
       }
     }
 


### PR DESCRIPTION
Closes #11 
---
Seeing that `dev-master` no longer exists @mallorydxw requested that the `README.md` be updated.

Are updates needed in these `composer.json` files also?
https://github.com/search?q=%22dxw%2Fphp-missing%22%3A+%22dev-master%22&type=code

